### PR TITLE
feat: Added missing census entries, also explained the structure of each entry

### DIFF
--- a/content/acnl/census-addresses.md
+++ b/content/acnl/census-addresses.md
@@ -17,67 +17,105 @@ Recently, I permanently broke my save file by messing with cheats. The game stil
 
 You can't hex edit the save file because then the game will say that it's corrupted, so you have to edit the values in RAM (using [Vapecord](https://github.com/RedShyGuy/Vapecord-ACNL-Plugin) for example), and then save the game. Since finding all the addresses wasn't fun, here's a list in case you need it (the save addresses are provided just because I found those first):
 
-## Addresses
+## Structure
 
-| Value                     | RAM addresses              | Save addresses (`garden_plus.dat`) |
-| ------------------------- | -------------------------- | ---------------------------------- |
-| Bells earned              | `0x31F57C10`, `0x31F57C14` | `0x72510`, `0x72514`               |
-| Bank account              | `0x31F57C24`, `0x31F57C28` | `0x72524`, `0x72528`               |
-| Bells spent               | `0x31F57C38`, `0x31F57C3C` | `0x72538`, `0x7253C`               |
-| Loans paid                | `0x31F57C4C`, `0x31F57C50` | `0x7254C`, `0x72550`               |
-| Turnips bought            | `0x31F57C60`, `0x31F57C64` | `0x72560`, `0x72564`               |
-| Turnips sold              | `0x31F57C74`, `0x31F57C78` | `0x72574`, `0x72578`               |
-| Turnip expenses           | `0x31F57C88`, `0x31F57C8C` | `0x72588`, `0x7258C`               |
-| Turnip profits            | `0x31F57C9C`, `0x31F57CA0` | `0x7259C`, `0x725A0`               |
-| Public works expenses     | `0x31F57CB0`, `0x31F57CB4` | `0x725B0`, `0x725B4`               |
-| Recycle Shop earnings     | `0x31F57CC4`, `0x31F57CC8` | `0x725C4`, `0x725C8`               |
-| Flowers watered           | `0x31F57CD8`, `0x31F57CDC` | `0x725D8`, `0x725DC`               |
-| Fish caught               | `0x31F57CEC`, `0x31F57CF0` | `0x725EC`, `0x725F0`               |
-| Bugs caught               | `0x31F57D00`, `0x31F57D04` | `0x72600`, `0x72604`               |
-| Sea creatures caught      | `0x31F57D14`, `0x31F57D18` | `0x72614`, `0x72618`               |
-| Public works built        | `0x31F57D28`               | `0x72628`                          |
-| Fruit grown               | `0x31F57D3C`               | `0x7263C`                          |
-| Perfect fruits grown      | `0x31F57D50`               | `0x72650`                          |
-| Fruits grown on the beach | `0x31F57D64`               | `0x72664`                          |
-| Flowers planted           | `0x31F57D78`, `0x31F57D7C` | `0x72678`, `0x7267C`               |
-| Trees planted             | `0x31F57D8C`, `0x31F57D90` | `0x7268C`, `0x72690`               |
-| Trees cut down            | `0x31F57DA0`, `0x31F57DA4` | `0x726A0`, `0x726A4`               |
-| K.K. Slider concerts      | `0x31F57DC8`, `0x31F57DCC` | `0x726C8`, `0x726CC`               |
-| Shrunk sketches           | `0x31F57DDC`, `0x31F57DE0` | `0x726DC`, `0x726E0`               |
-| Badges obtained           | `0x31F57DF0`, `0x31F57DF4` | `0x726F0`, `0x726F4`               |
-| Art pieces bought         | `0x31F57E04`, `0x31F57E08` | `0x72704`, `0x72708`               |
-| Letters sent              | `0x31F57E18`, `0x31F57E1C` | `0x72718`, `0x7271C`               |
-| Furniture customized      | `0x31F57E2C`, `0x31F57E30` | `0x7272C`, `0x72730`               |
-| Nookling’s expenses       | `0x31F57E40`, `0x31F57E44` | `0x72740`, `0x72744`               |
-| Gracie’s expenses         | `0x31F57E54`, `0x31F57E58` | `0x72754`, `0x72758`               |
-| Gardening shop expenses   | `0x31F57E68`, `0x31F57E6C` | `0x72768`, `0x7276C`               |
-| Weeds pulled              | `0x31F57E7C`, `0x31F57E80` | `0x7277C`, `0x72780`               |
-| StreetPass visitors       | `0x31F57ECC`, `0x31F57ED0` | Unknown                            |
-| Towns visited             | `0x31F57EE0`, `0x31F57EE4` | `0x727E0`, `0x727E4`               |
-| amiibo used               | `0x31F57F08`, `0x31F57F0C` | `0x72808`, `0x7280C`               |
-| Jobs at The Roost         | `0x31F57F1C`, `0x31F57F20` | `0x7281C`, `0x72820`               |
-| Fossils analyzed          | `0x31F57F30`, `0x31F57F34` | `0x72830`, `0x72834`               |
-| Island tours              | `0x31F57F5C`               | `0x7285C`                          |
-| Helped Gulliver           | `0x31F57F6C`, `0x31F57F70` | `0x7286C`, `0x72870`               |
-| Shampoodle visits         | `0x31F57F80`, `0x31F57F84` | `0x72880`, `0x72884`               |
-| Island visits             | `0x31F57F94`, `0x31F57F98` | `0x72894`, `0x72898`               |
-| Scallops given to Pascal  | `0x31F57FA8`, `0x31F57FAC` | `0x728A8`, `0x728AC`               |
-| Balloons popped           | `0x31F57FD0`, `0x31F57FD4` | `0x728D0`, `0x728D4`               |
-| Unknown                   | `0x31F580AC`, `0x31F580B0` | `0x729AC`, `0x729B0`               |
-| Sahara redecorations      | `0x31F58100`, `0x31F58104` | `0x72A00`, `0x72A04`               |
-| Lost items returned       | `0x31F58110`, `0x31F58114` | `0x72A10`, `0x72A14`               |
-| Villagers visited         | `0x31F58124`, `0x31F58128` | `0x72A24`, `0x72A28`               |
-| Visited by villagers      | `0x31F58138`, `0x31F5813C` | `0x72A38`, `0x72A3C`               |
-| Hide and seek matches     | `0x31F5814C`, `0x31F58150` | `0x72A4C`, `0x72A50`               |
-| Unknown                   | `0x31F58174`, `0x31F58178` | `0x72A74`, `0x72A78`               |
-| Unknown                   | `0x31F58188`, `0x31F5818C` | `0x72A88`, `0x72A8C`               |
-| DJ K.K. visits            | `0x31F581B0`, `0x31F581B4` | `0x72AB0`, `0x72AB4`               |
-| Initiatives completed     | `0x31F58200`, `0x31F58204` | `0x72B00`, `0x72B04`               |
-| Coupons earned            | `0x31F58214`, `0x31F58218` | `0x72B14`, `0x72B18`               |
-| Coupons spent             | `0x31F58228`, `0x31F5822C` | `0x72B28`, `0x72B2C`               |
-| Able Sisters' expenses    | `0x31F71390`, `0x31F71394` | `0x72790`, `0x72794`               |
-| Kicks’ expenses           | `0x31F713A4`, `0x31F713A8` | `0x727A4`, `0x727A8`               |
-| Katrina visits            | `0x31F713B8`, `0x31F713BC` | `0x727B8`, `0x727BC`               |
+```cpp
+struct ACNL_Cenus_Data_Type { //Size: 0x14 
+  uint32_t TotalPlayerStat; //All player stats combined
+  uint32_t PlayerStats[4]; //For each player
+};
+```
+
+This is the structure of each census entry. 
+It consists of 4 stat values for each player and a hidden stat value combining all 4 player stat values.
+
+## Offsets
+
+"Non Player specific" stats only have a value at `TotalPlayerStat`.
+"Has no total stat value" stats only have values at `PlayerStats[X]`.
+
+| Value                               | Save offset (`garden_plus.dat`) | Note                                                |
+|-------------------------------------|---------------------------------|-----------------------------------------------------|
+| Bells earned                        | `0x72510`                       |                                                     |
+| Bank account                        | `0x72524`                       |                                                     |
+| Bells spent                         | `0x72538`                       |                                                     |
+| Loans paid                          | `0x7254C`                       |                                                     |
+| Turnips bought                      | `0x72560`                       |                                                     |
+| Turnips sold                        | `0x72574`                       |                                                     |
+| Turnip expenses                     | `0x72588`                       |                                                     |
+| Turnip profits                      | `0x7259C`                       |                                                     |
+| Public works expenses               | `0x725B0`                       |                                                     |
+| Recycle Shop earnings               | `0x725C4`                       |                                                     |
+| Flowers watered                     | `0x725D8`                       |                                                     |
+| Fish caught                         | `0x725EC`                       |                                                     |
+| Bugs caught                         | `0x72600`                       |                                                     |
+| Sea creatures caught                | `0x72614`                       |                                                     |
+| Public works built                  | `0x72628`                       | Non Player specific                                 |
+| Fruit grown                         | `0x7263C`                       | Non Player specific                                 |
+| Perfect fruit grown                 | `0x72650`                       | Non Player specific                                 |
+| Fruits grown on the beach           | `0x72664`                       | Non Player specific                                 |
+| Flowers planted                     | `0x72678`                       |                                                     |
+| Trees planted                       | `0x7268C`                       |                                                     |
+| Trees cut down                      | `0x726A0`                       |                                                     |
+| Dream Towns Visited                 | `0x726B4`                       |                                                     |
+| K.K. Slider concerts                | `0x726C8`                       |                                                     |
+| Shrunk sketches                     | `0x726DC`                       |                                                     |
+| Island tours                        | `0x726F0`                       |                                                     |
+| Island visits                       | `0x72704`                       |                                                     |
+| Letters sent                        | `0x72718`                       |                                                     |
+| Furniture customized                | `0x7272C`                       |                                                     |
+| Nookling’s expenses                 | `0x72740`                       |                                                     |
+| Gracie’s expenses                   | `0x72754`                       |                                                     |
+| Gardening shop expenses             | `0x72768`                       |                                                     |
+| Weeds pulled                        | `0x7277C`                       |                                                     |
+| Able Sisters' expenses              | `0x72790`                       |                                                     |
+| Kicks’ expenses                     | `0x727A4`                       |                                                     |
+| Katrina visits                      | `0x727B8`                       |                                                     |
+| StreetPass visitors                 | `0x727CC`                       | Non Player specific                                 |
+| Towns visited                       | `0x727E0`                       |                                                     |
+| Town visitors                       | `0x727F4`                       |                                                     |
+| Sahara redecorations                | `0x72808`                       |                                                     |
+| Jobs at The Roost                   | `0x7281C`                       |                                                     |
+| Fossils analyzed                    | `0x72830`                       |                                                     |
+| Pro Designs created                 | `0x72844`                       |                                                     |
+| Badges obtained                     | `0x72858`                       | Has no total stat value                             |
+| Helped Gulliver                     | `0x7286C`                       |                                                     |
+| Shampoodle visits                   | `0x72880`                       |                                                     |
+| Art pieces bought                   | `0x72894`                       |                                                     |
+| Scallops given to Pascal            | `0x728A8`                       |                                                     |
+| Unknown 0                           | `0x728BC`                       |                                                     |
+| Balloons popped                     | `0x728D0`                       |                                                     |
+| Tourney Fish caught                 | `0x728E4`                       | Cleared when event ends                             |
+| Tourney Insect caught               | `0x728F8`                       | Cleared when event ends                             |
+| Festival Feathers caught            | `0x7290C`                       | Cleared when event ends                             |
+| Eggs given to Zipper                | `0x72920`                       | Cleared when event ends                             |
+| Found imposter Blanca               | `0x72934`                       | Cleared when event ends                             |
+| Firework Designs given to Isabelle  | `0x72948`                       | Set after fireworks start / cleared when event ends |
+| Received Candy on Halloween         | `0x7295C`                       | Cleared when event ends                             |
+| Harvest Festival Courses done       | `0x72970`                       | Cleared when event ends                             |
+| Snowmen built by you in Town        | `0x72984`                       | Cleared when snowman melts                          |
+| Given Toy Day presents              | `0x72998`                       | Cleared when event ends                             |
+| Snowflakes caught                   | `0x729AC`                       | Cleared when it stops snowing                       |
+| PartyPoppers popped at New Years    | `0x729C0`                       | Cleared when event ends                             |
+| Total Bingo wins                    | `0x729D4`                       |                                                     |
+| Shooting Star wishes                | `0x729E8`                       |                                                     |
+| Unknown 1                           | `0x729FC`                       |                                                     |
+| Lost items returned                 | `0x72A10`                       |                                                     |
+| Visited by villagers                | `0x72A24`                       |                                                     |
+| Villagers visited                   | `0x72A38`                       |                                                     |
+| Hide and seek matches               | `0x72A4C`                       |                                                     |
+| Unknown 2                           | `0x72A60`                       |                                                     |
+| Unknown 3                           | `0x72A74`                       |                                                     |
+| amiibo used                         | `0x72A88`                       |                                                     |
+| Reset Surveillance Center visits    | `0x72A9C`                       |                                                     |
+| DJ K.K. visits                      | `0x72AB0`                       |                                                     |
+| Golden Roses created                | `0x72AC4`                       | Non Player specific                                 |
+| Unknown 4                           | `0x72AD8`                       | Non Player specific                                 |
+| Famous Mushrooms eaten              | `0x72AEC`                       |                                                     |
+| Initiatives completed               | `0x72B00`                       |                                                     |
+| Coupons earned                      | `0x72B14`                       |                                                     |
+| Coupons spent                       | `0x72B28`                       |                                                     |
+| Unused                              | `0x72B3C`                       | Non Player specific / most likely unused            |
 
 ## Tools used
 


### PR DESCRIPTION
Good job on researching the offsets. :)
To further improve your data I added the actual structure of each census entry.
Also I added all the missing ones you didn't add.
And some were not in the proper order.

I did remove the addresses you added, as they aren't helpful anyways. Each game region uses different addresses. And as you didn't declare which region these are, they were useless.
Having the base address of the garden plus is enough to then go to each offset.